### PR TITLE
Ignore future changes to .docker-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 emoncms/
+.docker-env


### PR DESCRIPTION
By adding `.docker-env` to the `.gitignore` it will ignore changes users make locally, so it won't try to add their passwords into version control.
