### PR TITLE
Wrong path for volume inside the mysql container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - "MYSQL_HOST=localhost"
     volumes:
-      - emon-db-data:/var/lib/mysql/data
+      - emon-db-data:/var/lib/mysql
   redis:
     # Official redis image
     image: redis:3.0.7


### PR DESCRIPTION
The volume as defined in the image is really /var/lib/mysql, NOT  /var/lib/mysql/data
See line 63 at  https://github.com/docker-library/mysql/blob/883703dfb30d9c197e0059a669c4bb64d55f6e0d/5.6/Dockerfile 

Before this commit, the database is lost if the mysql container is recreated or the whole thing is updated using ```docker-compose build && docker-compose down && docker-compose up -d --force-recreate```