### PR TITLE
Fixed issues installing packages php5-curl, php5-mysql and php5-json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ FROM php:5.6-apache
 # Install deps
 RUN apt-get update && apt-get install -y \
               libcurl4-gnutls-dev \
-              php5-curl \
-              php5-json \
-              php5- mcrypt \
-              php5-mysql \
               libmcrypt-dev \
               git-core
 


### PR DESCRIPTION
Installing the php packages php5-curl, php5-mysql and php5-json seems to make problems. I removed the packages from the install list and they are compiled just fine through the docker-php-ext-install command. For me this fix seems to work fine.