### PR TITLE
Switched to PHP 7.0 and added basic MQTT support (publish to MQTT only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 # Offical Docker PHP & Apache image https://hub.docker.com/_/php/
-# To do: fix compatiability with php 7
-FROM php:5.6-apache
+FROM php:7.0-apache
 
 # Install deps
 RUN apt-get update && apt-get install -y \
               libcurl4-gnutls-dev \
               libmcrypt-dev \
+              libmosquitto-dev \
               git-core
 
 # Enable PHP modules
-RUN docker-php-ext-install -j$(nproc) mysql mysqli curl json mcrypt gettext
-RUN pecl install redis-2.2.8 \
+RUN docker-php-ext-install -j$(nproc) mysqli curl json mcrypt gettext
+RUN pecl install redis-3.1.6 \
   \ && docker-php-ext-enable redis
+RUN pecl install Mosquitto-0.4.0 \
+  \ && docker-php-ext-enable mosquitto
 
 RUN a2enmod rewrite
 
@@ -47,5 +49,3 @@ RUN chmod 666 /var/log/emoncms.log
 # Add Pecl :
 # - dio
 # - Swiftmailer
-# - redis
-# - mqtt

--- a/default.docker-env
+++ b/default.docker-env
@@ -15,3 +15,10 @@ REDIS_PORT=6379
 # At the moment Docker doesn't honour the REDIS_AUTH variable, so it will always be passwordless
 # REDIS_AUTH=
 REDIS_PREFIX='emoncms'
+
+# MQTT
+MQTT_ENABLED=false
+MQTT_HOST=localhost
+MQTT_USER=YOUR_MQTT_USER
+MQTT_PASSWORD=YOUR_MQTT_PASSWORD
+MQTT_BASETOPIC=emon

--- a/docker.settings.php
+++ b/docker.settings.php
@@ -25,12 +25,12 @@
 //3 #### MQTT
     // The 'subscriber' topic format is rx/* - where * is the emoncms input node number.
     // The 'publisher' topic format is user selectable from the 'Publish to MQTT' input process, for example power/solar
-    $mqtt_enabled = false;          // Activate MQTT by changing to true
-    $mqtt_server = array( 'host'     => 'localhost',
-                          'port'     => 1883,
-                          'user'     => '',
-                          'password' => '',
-                          'basetopic'=> 'emon'
+    $mqtt_enabled = isset($_ENV["MQTT_ENABLED"]) ? $_ENV["MQTT_ENABLED"] === 'true' : false;
+    $mqtt_server = array( 'host'     => isset($_ENV["MQTT_HOST"])      ? $_ENV["MQTT_HOST"]      : 'localhost',
+                          'port'     => isset($_ENV["MQTT_PORT"])      ? $_ENV["MQTT_PORT"]      : 1883,
+                          'user'     => isset($_ENV["MQTT_USER"])      ? $_ENV["MQTT_USER"]      : '',
+                          'password' => isset($_ENV["MQTT_PASSWORD"])  ? $_ENV["MQTT_PASSWORD"]  : '',
+                          'basetopic'=> isset($_ENV["MQTT_BASETOPIC"]) ? $_ENV["MQTT_BASETOPIC"] : 'emon'
                           );
 
 


### PR DESCRIPTION
I switched the base image to PHP 7 and added basic MQTT support. MQTT is only working for publishing to MQTT yet, but the service for receiving data is not yet added. I have experimented with adding the service, but I cannot test it properly since I am only running IotaWatts with my emoncms installation.