### PR TITLE
redis/mysql: update to recent versions to support aarch64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,14 @@ services:
   db:
     # Official MYSQL docker image
     # To do: make compatiable with 5.7
-    image: mysql:5.6
+    image: mariadb:10
     environment:
       - "MYSQL_HOST=localhost"
     volumes:
       - emon-db-data:/var/lib/mysql
   redis:
     # Official redis image
-    image: redis:3.0.7
+    image: redis:5
     volumes:
       - emon-redis-data:/data
 


### PR DESCRIPTION
mysql -> mariadb 10
redis 3.0.7 -> redis 5

Tested basic sanity of loading feeds and inserting data on an odroid c2.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

Fixes https://github.com/emoncms/emoncms-docker/issues/20

(redis had to be updated as well)