### PR TITLE
Revamp workflow and dockerfile to modulate php version

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,25 +25,25 @@ jobs:
     steps:
     # Checkout the repository code
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Log in to Docker Hub
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - id: emoncms_version
-        name: get emoncms version
-        run: |
-          wget https://raw.githubusercontent.com/${{ inputs.emoncms_src }}/${{ inputs.branch }}/version.json
-          version=$(cat version.json | jq --raw-output '.version')
-          echo $version
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      name: get emoncms version
+      run: |
+        wget https://raw.githubusercontent.com/${{ inputs.emoncms_src }}/${{ inputs.branch }}/version.json
+        version=$(cat version.json | jq --raw-output '.version')
+        echo $version
+        echo "version=$version" >> "$GITHUB_OUTPUT"
 
     # Build and push Docker image
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: ./web
         build-args: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,13 +1,27 @@
-name: Build and Push Docker Image
+name: Build and Push emoncms legacy Docker Image
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      php_version:
+        description: 'php_version'
+        required: true
+        type: string
+        default: '8.2.27'
+      emoncms_src:
+        description: 'emoncms_src'
+        required: true
+        type: string
+        default: 'emoncms/emoncms'
+      branch:
+        description: 'branch'
+        required: true
+        type: string
+        default: 'stable'
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-
     steps:
     # Checkout the repository code
     - name: Checkout code
@@ -19,13 +33,24 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - id: emoncms_version
+        name: get emoncms version
+        run: |
+          wget https://raw.githubusercontent.com/${{ inputs.emoncms_src }}/${{ inputs.branch }}/version.json
+          version=$(cat version.json | jq --raw-output '.version')
+          echo $version
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
     # Build and push Docker image
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:
         context: ./web
+        build-args: |
+            "BUILD_FROM=php:${{ inputs.php_version }}-apache"
+            "EMONCMS_SRC=https://github.com/${{ inputs.emoncms_src }}"
+            "BRANCH=${{ inputs.branch }}"
         push: true
         tags: |
           openenergymonitor/emoncms:latest
-          openenergymonitor/emoncms:${{ github.event.release.tag_name }}
+          openenergymonitor/emoncms:${{ steps.emoncms_version.outputs.version }}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,22 @@
+ARG BUILD_FROM=php:8.0-apache
+
 # Offical Docker PHP & Apache image https://hub.docker.com/_/php/
-FROM php:8.0-apache
+FROM $BUILD_FROM
+
+ARG \
+    EMONCMS_SRC=https://github.com/emoncms/emoncms \
+    BRANCH=master \
+    DAEMON=www-data \
+    WWW=/var/www \
+    OEM_DIR=/opt/openenergymonitor \
+    EMONCMS_DIR=/opt/emoncms \
+    EMONCMS_LOG_LOCATION=/var/log/emoncms \
+    EMONCMS_DATADIR=/var/opt/emoncms
+    
 
 # Install deps
 RUN apt-get update && apt-get install -y \
+              iproute2 \
               libcurl4-gnutls-dev \
               libmcrypt-dev \
               gettext \
@@ -33,31 +47,42 @@ COPY config/emoncms.conf /etc/apache2/sites-available/emoncms.conf
 RUN a2dissite 000-default.conf
 RUN a2ensite emoncms
 
-# NOT USED ANYMORE - GIT CLONE INSTEAD
-# Copy in emoncms files, files can be mounted from local FS for dev see docker-compose
-# ADD ./emoncms /var/www/html
-
 # Clone in master Emoncms repo & modules - overwritten in development with local FS files
-RUN mkdir /var/www/emoncms
-RUN git clone -b '11.6.9' --single-branch https://github.com/emoncms/emoncms.git /var/www/emoncms
-RUN git clone https://github.com/emoncms/dashboard.git /var/www/emoncms/Modules/dashboard
-RUN git clone https://github.com/emoncms/graph.git /var/www/emoncms/Modules/graph
-RUN git clone https://github.com/emoncms/app.git /var/www/emoncms/Modules/app
-RUN git clone https://github.com/emoncms/device.git /var/www/emoncms/Modules/device
+RUN \
+    set -x;\
+    mkdir -p $OEM_DIR;\
+    cd $WWW && git clone -b $BRANCH $EMONCMS_SRC;\
+    cd $WWW/emoncms/Modules && git clone https://github.com/emoncms/dashboard;\
+    cd $WWW/emoncms/Modules && git clone https://github.com/emoncms/graph;\
+    cd $WWW/emoncms/Modules && git clone https://github.com/emoncms/app;\
+    cd $WWW/emoncms/Modules && git clone https://github.com/emoncms/device;\
+    chown -R $DAEMON $WWW/emoncms
+
+WORKDIR $OEM_DIR
+
+RUN \
+    set -x;\
+    git config --system --replace-all safe.directory '*';\
+    git clone https://github.com/openenergymonitor/EmonScripts;\
+    cp EmonScripts/install/emonsd.config.ini EmonScripts/install/config.ini
 
 COPY docker.settings.ini /var/www/emoncms/settings.ini
 
 # Create folders & set permissions for feed-engine data folders (mounted as docker volumes in docker-compose)
-RUN mkdir /var/opt/emoncms
-RUN mkdir /var/opt/emoncms/phpfina
-RUN mkdir /var/opt/emoncms/phptimeseries
-RUN chown www-data:root /var/opt/emoncms/phpfina
-RUN chown www-data:root /var/opt/emoncms/phptimeseries
+RUN \
+    set -x;\
+    mkdir $EMONCMS_DATADIR;\
+    mkdir $EMONCMS_DATADIR/phpfina;\
+    mkdir $EMONCMS_DATADIR/phptimeseries;\
+    chown -R $DAEMON $EMONCMS_DATADIR
 
 # Create Emoncms logfile
-RUN mkdir /var/log/emoncms
-RUN touch /var/log/emoncms/emoncms.log
-RUN chmod 666 /var/log/emoncms/emoncms.log
+RUN \
+    set -x;\
+    mkdir -p $EMONCMS_LOG_LOCATION;\
+    chown $DAEMON $EMONCMS_LOG_LOCATION;\
+    touch $EMONCMS_LOG_LOCATION/emoncms.log;\
+    chmod 666 $EMONCMS_LOG_LOCATION/emoncms.log
 
 # To start Apache and emoncms_mqtt from supervisord
 COPY config/supervisord.conf /etc/supervisor/supervisord.conf

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,5 @@
+# how to build
+
+```
+docker build --build-arg="BUILD_FROM=php:8.2.27-apache" -t emoncms_legacy_docker .
+```


### PR DESCRIPTION
This commit improves the Dockerfile so you can use ARGS to define a php version
It automatically detect the emoncms version to tag the image pushed to the hub, so you have no risk of error (previous tag 11.6.10 is 11.6.9)
The push has to be done manually :
Go to actions, choose the workflow, adjust the ARGS and run :
![image](https://github.com/user-attachments/assets/e934fc5d-645b-41bc-94da-d9dd2fb4e9d3)
